### PR TITLE
Add typings (index.d.ts) to the package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,68 @@
+/** A utility that returns a promise that resolves when the passed function returns true. */
+declare function until(
+  /** A function that returns a truthy value once the promise should be resolved. `until` will call this function repeatedly until it returns `true` or the timeout elapses. */
+  checkFunc: (setError: (error: Error) => void) => boolean | Promise<boolean>,
+  /** The number of milliseconds to wait before timing out and rejecting the promise. Defaults to `1000`. */
+  timeout?: number,
+  /** A message to help identify failing cases. For example, setting this to `"value == 42"` will reject with an error of `"timed out waiting until value == 42"` if it times out. Defaults to `"something happens"`. */
+  message?: string
+): Promise<void>;
+
+/** A utility that returns a promise that resolves when the passed function returns true. */
+declare function until(
+  /** A function that returns a truthy value once the promise should be resolved. `until` will call this function repeatedly until it returns `true` or the timeout elapses. */
+  checkFunc: (setError: (error: Error) => void) => boolean | Promise<boolean>,
+  /** A message to help identify failing cases. For example, setting this to `"value == 42"` will reject with an error of `"timed out waiting until value == 42"` if it times out. Defaults to `"something happens"`. */
+  message?: string,
+  /** The number of milliseconds to wait before timing out and rejecting the promise. Defaults to `1000`. */
+  timeout?: number
+): Promise<void>;
+
+/** A utility that returns a promise that resolves when the passed function returns true. */
+declare function until(
+  /** The number of milliseconds to wait before timing out and rejecting the promise. Defaults to `1000`. */
+  timeout: number,
+  /** A function that returns a truthy value once the promise should be resolved. `until` will call this function repeatedly until it returns `true` or the timeout elapses. */
+  checkFunc: (setError: (error: Error) => void) => boolean | Promise<boolean>,
+  /** A message to help identify failing cases. For example, setting this to `"value == 42"` will reject with an error of `"timed out waiting until value == 42"` if it times out. Defaults to `"something happens"`. */
+  message?: string
+): Promise<void>;
+
+/** A utility that returns a promise that resolves when the passed function returns true. */
+declare function until(
+  /** A message to help identify failing cases. For example, setting this to `"value == 42"` will reject with an error of `"timed out waiting until value == 42"` if it times out. Defaults to `"something happens"`. */
+  message: string,
+  /** A function that returns a truthy value once the promise should be resolved. `until` will call this function repeatedly until it returns `true` or the timeout elapses. */
+  checkFunc: (setError: (error: Error) => void) => boolean | Promise<boolean>,
+  /** The number of milliseconds to wait before timing out and rejecting the promise. Defaults to `1000`. */
+  timeout?: number
+): Promise<void>;
+
+/** A utility that returns a promise that resolves when the passed function returns true. */
+declare function until(
+  /** The number of milliseconds to wait before timing out and rejecting the promise. Defaults to `1000`. */
+  timeout: number,
+  /** A message to help identify failing cases. For example, setting this to `"value == 42"` will reject with an error of `"timed out waiting until value == 42"` if it times out. Defaults to `"something happens"`. */
+  message: string,
+  /** A function that returns a truthy value once the promise should be resolved. `until` will call this function repeatedly until it returns `true` or the timeout elapses. */
+  checkFunc: (setError: (error: Error) => void) => boolean | Promise<boolean>
+): Promise<void>;
+
+/** A utility that returns a promise that resolves when the passed function returns true. */
+declare function until(
+  /** A message to help identify failing cases. For example, setting this to `"value == 42"` will reject with an error of `"timed out waiting until value == 42"` if it times out. Defaults to `"something happens"`. */
+  message: string,
+  /** The number of milliseconds to wait before timing out and rejecting the promise. Defaults to `1000`. */
+  timeout: number,
+  /** A function that returns a truthy value once the promise should be resolved. `until` will call this function repeatedly until it returns `true` or the timeout elapses. */
+  checkFunc: (setError: (error: Error) => void) => boolean | Promise<boolean>
+): Promise<void>;
+
+declare namespace until {
+  /** The current default timeout. It's 1000 by default. */
+  let defaultTimeout: number;
+  /** Sets the default timeout in milliseconds. Passing a falsy ms resets to the default of 1000. */
+  const setDefaultTimeout: (ms: number) => void;
+}
+
+export = until;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1",
   "description": "Utility method that returns a promise that resolves when a condition returns true",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "mocha test"
   },


### PR DESCRIPTION
Thanks for creating this lib!

One thing I missed on it was proper typings, so I added them. I hope it's useful for other devs.

The typings were added with overloads, so intellisense will automatically match the current usage:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/418083/90989253-d12b6980-e5a1-11ea-897a-ef7d2be6386d.png">

![image](https://user-images.githubusercontent.com/418083/90989387-25cee480-e5a2-11ea-863b-16421cfe9f43.png)

Note: The "setMessage" optional-argument for the callback was left like that (without the question mark) as recommended by [Overloads and Callbacks](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#overloads-and-callbacks) section from the TypeScript Handbook.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/418083/90989525-143a0c80-e5a3-11ea-9d92-e02ef07ea7dd.png">
